### PR TITLE
Replace Arc<Client> with Client

### DIFF
--- a/crates/server/src/core/session.rs
+++ b/crates/server/src/core/session.rs
@@ -10,7 +10,7 @@ use dashmap::{
     DashMap,
 };
 use futures::stream::{self, StreamExt};
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio::time::timeout;
 use tower_lsp::{lsp_types::*, Client};
 use zerocopy::AsBytes;
@@ -18,7 +18,7 @@ use zerocopy::AsBytes;
 /// Represents the current state of the LSP service.
 pub(crate) struct Session {
     /// The LSP client handle.
-    pub(crate) client: Arc<Client>,
+    pub(crate) client: Client,
     /// The document metadata database.
     database: Database,
     /// The store of currently open documents.
@@ -27,7 +27,7 @@ pub(crate) struct Session {
 
 impl Session {
     /// Create a new session.
-    pub(crate) fn new(client: Arc<Client>) -> Fallible<Self> {
+    pub(crate) fn new(client: Client) -> Fallible<Self> {
         let database = Database::new()?;
         let documents = DashMap::new();
         Ok(Session {

--- a/crates/server/src/lsp/server.rs
+++ b/crates/server/src/lsp/server.rs
@@ -7,7 +7,7 @@ use tower_lsp::Client;
 /// The WASM language server instance.
 pub struct Server {
     /// The LSP client handle.
-    pub(crate) client: Arc<Client>,
+    pub(crate) client: Client,
     /// The current state of the server.
     pub(crate) session: Arc<Session>,
 }
@@ -15,7 +15,6 @@ pub struct Server {
 impl Server {
     /// Create a new server.
     pub fn new(client: Client) -> Fallible<Self> {
-        let client = Arc::new(client);
         let session = Arc::new(Session::new(client.clone())?);
         Ok(Server { client, session })
     }


### PR DESCRIPTION
Since `tower_lsp::Client` is already cloneable and contains an `Arc` internally for cheap reference-counted cloning and sharing, the outer `Arc` should be unnecessary. 😄