### PR TITLE
Upgrade to tower-lsp 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
 name = "tower-lsp"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fffe96b81d118354ffb5605a1defab5178dd6255250a371bbb81d53bc1f8644"
+checksum = "5d4af561060ca4fb5c6f10ff1c8bcd1bc95ee957211ee3e8e1a7a4a43abd49fa"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822fa97904c3983765a6e8ecc5ee943e7d0f98bb19023696791f16152447946a"
+checksum = "5c51c24e3b5909be30d6ed472f934aa9b7d91abf2688013956b296b1d1e7b186"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = { version = "1.0", optional = true }
 sled = "0.34.0"
 thiserror = "1.0.14"
 tokio = { version = "0.2.13", features = ["io-std", "macros", "sync", "time"] }
-tower-lsp = "0.12.0"
+tower-lsp = "0.13.0"
 tower-test = { version = "0.3.0", optional = true }
 tree-sitter = "0.16.1"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/crates/server/src/lsp/api.rs
+++ b/crates/server/src/lsp/api.rs
@@ -15,7 +15,7 @@ impl LanguageServer for Server {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client.log_message(MessageType::Info, "server initialized!");
+        self.client.log_message(MessageType::Info, "server initialized!").await;
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/crates/server/src/service/auditor.rs
+++ b/crates/server/src/service/auditor.rs
@@ -92,7 +92,7 @@ pub(crate) mod tree {
             }
             // NOTE: else let elaborator handle
             let version = None;
-            session.client.publish_diagnostics(uri.clone(), diagnostics, version);
+            session.client.publish_diagnostics(uri, diagnostics, version).await;
         }
         Ok(())
     }
@@ -103,7 +103,7 @@ pub(crate) mod tree {
         // FIXME: handle this properly
         let diagnostics = vec![];
         let version = None;
-        session.client.publish_diagnostics(uri, diagnostics, version);
+        session.client.publish_diagnostics(uri, diagnostics, version).await;
         Ok(())
     }
 

--- a/crates/server/src/service/auditor.rs
+++ b/crates/server/src/service/auditor.rs
@@ -14,83 +14,86 @@ pub(crate) mod tree {
     pub(crate) async fn change(session: Arc<Session>, uri: Url) -> Fallible<()> {
         if let Some(document) = session.get_document(&uri).await? {
             let tree = document.tree.lock().await.clone();
-            let node = tree.root_node();
-            let mut diagnostics = vec![];
-            if node.has_error() {
-                // prepare a query to match tree-sitter ERROR nodes
-                let language = tree.language();
-                let source = "((ERROR) @error)"; // query the tree for ERROR nodes
-                let query = tree_sitter::Query::new(language, source).map_err(Error::TreeSitterQueryError)?;
+            let diagnostics = {
+                let mut diagnostics = vec![];
+                let node = tree.root_node();
+                if node.has_error() {
+                    // prepare a query to match tree-sitter ERROR nodes
+                    let language = tree.language();
+                    let source = "((ERROR) @error)"; // query the tree for ERROR nodes
+                    let query = tree_sitter::Query::new(language, source).map_err(Error::TreeSitterQueryError)?;
 
-                // prepare a query cursor
-                let mut query_cursor = tree_sitter::QueryCursor::new();
-                let text_callback = |node: tree_sitter::Node| &document.text[node.byte_range()];
-                let matches = query_cursor.matches(&query, node, text_callback);
+                    // prepare a query cursor
+                    let mut query_cursor = tree_sitter::QueryCursor::new();
+                    let text_callback = |node: tree_sitter::Node| &document.text[node.byte_range()];
+                    let matches = query_cursor.matches(&query, node, text_callback);
 
-                // iterate the query cursor and construct appropriate lsp diagnostics
-                for tree_sitter::QueryMatch { captures, .. } in matches {
-                    'captures: for tree_sitter::QueryCapture { node, .. } in captures {
-                        // create a cursor node starting from the capture node
-                        let mut cursor = *node;
+                    // iterate the query cursor and construct appropriate lsp diagnostics
+                    for tree_sitter::QueryMatch { captures, .. } in matches {
+                        'captures: for tree_sitter::QueryCapture { node, .. } in captures {
+                            // create a cursor node starting from the capture node
+                            let mut cursor = *node;
 
-                        // traverse upward through the parent nodes
-                        'cursor: while let Some(parent) = cursor.parent() {
-                            cursor = parent;
-                            // ignore further processing if the first non-ERROR
-                            // parent node is a comment node; we do this in
-                            // order to avoid syntax errors due to encoding
-                            // issues (see "comments.wast" and issue #42)
-                            if !cursor.is_error() {
-                                match document.language {
-                                    Language::Wast
-                                        if [
-                                            *wast::kind::COMMENT_BLOCK_ANNOT,
-                                            *wast::kind::COMMENT_BLOCK,
-                                            *wast::kind::COMMENT_LINE_ANNOT,
-                                            *wast::kind::COMMENT_LINE,
-                                        ]
-                                        .contains(&parent.kind_id()) =>
-                                    {
-                                        break 'captures;
+                            // traverse upward through the parent nodes
+                            'cursor: while let Some(parent) = cursor.parent() {
+                                cursor = parent;
+                                // ignore further processing if the first non-ERROR
+                                // parent node is a comment node; we do this in
+                                // order to avoid syntax errors due to encoding
+                                // issues (see "comments.wast" and issue #42)
+                                if !cursor.is_error() {
+                                    match document.language {
+                                        Language::Wast
+                                            if [
+                                                *wast::kind::COMMENT_BLOCK_ANNOT,
+                                                *wast::kind::COMMENT_BLOCK,
+                                                *wast::kind::COMMENT_LINE_ANNOT,
+                                                *wast::kind::COMMENT_LINE,
+                                            ]
+                                            .contains(&parent.kind_id()) =>
+                                        {
+                                            break 'captures;
+                                        }
+                                        Language::Wat
+                                            if [
+                                                *wat::kind::COMMENT_BLOCK_ANNOT,
+                                                *wat::kind::COMMENT_BLOCK,
+                                                *wat::kind::COMMENT_LINE_ANNOT,
+                                                *wat::kind::COMMENT_LINE,
+                                            ]
+                                            .contains(&parent.kind_id()) =>
+                                        {
+                                            break 'captures;
+                                        }
+                                        _ => {
+                                            break 'cursor;
+                                        },
                                     }
-                                    Language::Wat
-                                        if [
-                                            *wat::kind::COMMENT_BLOCK_ANNOT,
-                                            *wat::kind::COMMENT_BLOCK,
-                                            *wat::kind::COMMENT_LINE_ANNOT,
-                                            *wat::kind::COMMENT_LINE,
-                                        ]
-                                        .contains(&parent.kind_id()) =>
-                                    {
-                                        break 'captures;
-                                    }
-                                    _ => {
-                                        break 'cursor;
-                                    },
                                 }
                             }
-                        }
 
-                        let start = node.start_position();
-                        let end = node.end_position();
-                        diagnostics.push({
-                            let range = {
-                                let start = Position::new(start.row as u64, start.column as u64);
-                                let end = Position::new(end.row as u64, end.column as u64);
-                                Range::new(start, end)
-                            };
-                            let severity = Some(DiagnosticSeverity::Error);
-                            let code = None;
-                            let source = Some(String::from("wasm-lsp"));
-                            let message = String::from("syntax error");
-                            let related_information = None;
-                            let tags = None;
-                            Diagnostic::new(range, severity, code, source, message, related_information, tags)
-                        });
+                            let start = node.start_position();
+                            let end = node.end_position();
+                            diagnostics.push({
+                                let range = {
+                                    let start = Position::new(start.row as u64, start.column as u64);
+                                    let end = Position::new(end.row as u64, end.column as u64);
+                                    Range::new(start, end)
+                                };
+                                let severity = Some(DiagnosticSeverity::Error);
+                                let code = None;
+                                let source = Some(String::from("wasm-lsp"));
+                                let message = String::from("syntax error");
+                                let related_information = None;
+                                let tags = None;
+                                Diagnostic::new(range, severity, code, source, message, related_information, tags)
+                            });
+                        }
                     }
                 }
-            }
-            // NOTE: else let elaborator handle
+                // NOTE: else let elaborator handle
+                diagnostics
+            };
             let version = None;
             session.client.publish_diagnostics(uri, diagnostics, version).await;
         }


### PR DESCRIPTION
[See changes in release v0.13.0](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.13.0) for details!

**Note:** since all the `Client` methods have been changed to `async fn`, as described in https://github.com/ebkalderon/tower-lsp/issues/180#issuecomment-671050331, I identified a compile error caused by `tree-sitter` interacting poorly with async/await and `Send` futures:

```
error: future cannot be sent between threads safely
  --> crates/server/src/lsp/api.rs:25:65
   |
25 |       async fn did_open(&self, params: DidOpenTextDocumentParams) {
   |  _________________________________________________________________^
26 | |         crate::service::synchronizer::document::open(self.session.clone(), params)
27 | |             .await
28 | |             .unwrap()
29 | |     }
   | |_____^ future returned by `__did_open` is not `Send`
   |
   = help: within `impl core::future::future::Future`, the trait `std::marker::Send` is not implemented for `*const std::ffi::c_void`
note: future is not `Send` as this value is used across an await
  --> crates/server/src/service/auditor.rs:95:13
   |
17 |             let node = tree.root_node();
   |                 ---- has type `tree_sitter::Node<'_>` which is not `Send`
...
95 |             session.client.publish_diagnostics(uri.clone(), diagnostics, version).await;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ await occurs here, with `node` maybe used later
96 |         }
   |         - `node` is later dropped here
   = note: required for the cast to the object type `dyn core::future::future::Future<Output = ()> + std::marker::Send`
```

This is fixed by wrapping the `node` variable in a lexical scope so that the variable gets dropped early before the `session.client.publish_diagnostics(...).await;` call occurs. This solution was inspired by https://github.com/rust-lang/rust/pull/64856.

Let me know what you think, @darinmorrison! Does this look good to you? Any suggestions?