### PR TITLE
Update wast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,8 +1795,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff1e3bd3ad0b2ee7784add89c30dc96b89a54b43e5d6d95d774eda1863b3500"
+source = "git+https://github.com/darinmorrison/wasm-tools?branch=update-simd#fd6380b5b262b684f5d562e6cf8bd4f9a782a007"
 dependencies = [
  "leb128",
 ]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,7 +48,7 @@ tower-lsp = "0.13"
 tree-sitter = "0.16"
 uuid = { version = "0.8", features = ["v4"] }
 wasm-language-server-parsers = { path = "../parsers" }
-wast = "24.0"
+wast = { git = "https://github.com/darinmorrison/wasm-tools", branch = "update-simd" }
 zerocopy = "0.3"
 
 [dev-dependencies]

--- a/crates/server/src/provider/diagnostics.rs
+++ b/crates/server/src/provider/diagnostics.rs
@@ -27,7 +27,7 @@ fn for_error(document: &Document, error: wast::Error) -> Diagnostic {
 // reporting (because tree-sitter does not provide detailed errors yet).
 fn for_change(document: &Document, tree: tree_sitter::Tree) -> anyhow::Result<Vec<Diagnostic>> {
     let mut diagnostics = vec![];
-    if tree.root_node().has_error() {
+    if tree.root_node().has_error() || cfg!(debug_assertions) {
         match ::wast::parser::ParseBuffer::new(&document.text) {
             Err(error) => {
                 diagnostics.push(super::diagnostics::for_error(document, error));

--- a/crates/server/tests/all/lsp.rs
+++ b/crates/server/tests/all/lsp.rs
@@ -143,7 +143,7 @@ mod text_document {
         let uri = Url::parse("inmemory:///test")?;
         let language_id = "wasm.wat";
 
-        let old_text = String::from("");
+        let old_text = String::from("(module)");
         let new_text = String::from("(module $m (func $f))");
 
         let (ref mut service, ref mut messages) = testing::service::spawn()?;
@@ -212,7 +212,7 @@ mod text_document {
             let uri = Url::parse("inmemory:///test")?;
             let language_id = "wasm.wat";
 
-            let old_text = String::from("");
+            let old_text = String::from("(module)");
             let new_text = String::from("(module (func (export \"\\x\"))");
 
             let (ref mut service, ref mut messages) = testing::service::spawn()?;
@@ -289,7 +289,7 @@ mod text_document {
             let uri = Url::parse("inmemory:///test")?;
             let language_id = "wasm.wat";
 
-            let old_text = String::from("");
+            let old_text = String::from("(module)");
             let new_text = String::from("(modu)");
 
             let (ref mut service, ref mut messages) = testing::service::spawn()?;
@@ -366,7 +366,7 @@ mod text_document {
     async fn did_close() -> anyhow::Result<()> {
         let uri = Url::parse("inmemory:///test")?;
         let language_id = "wasm.wast";
-        let text = String::new();
+        let text = String::from("(module)");
 
         let (ref mut service, ref mut messages) = testing::service::spawn()?;
 
@@ -421,7 +421,7 @@ mod text_document {
     async fn did_open() -> anyhow::Result<()> {
         let uri = Url::parse("inmemory:///test")?;
         let language_id = "wasm.wast";
-        let text = String::new();
+        let text = String::from("(module)");
 
         let (ref mut service, ref mut messages) = testing::service::spawn()?;
 


### PR DESCRIPTION
This switches the wast dependency to our local fork with the updated simd instructions and includes some other small changes to facilitate testing.

Related: https://github.com/bytecodealliance/wasm-tools/pull/110